### PR TITLE
Remove referral multipier setting

### DIFF
--- a/attributes.yml
+++ b/attributes.yml
@@ -38,10 +38,6 @@ custom_attribute_collections:
         value: <em>Increase your chance of winning</em> by sharing this prize draw with friends!</em>
         help_text: Feel free to change the copy of the referral instructions if you like.
         type: wysiwyg
-      referral_multiplier:
-        value: 3
-        help_text: How many extra entries should your prize draw participants get for each converted referral?
-        type: number
   appearance:
     title: Appearance
     help_title: Change the way your prize draw looks


### PR DESCRIPTION
https://3.basecamp.com/3209127/buckets/3818850/todos/573248140 to hide the multiplier input for now. 

If once we deployed again that it remains on the theme, we can manually remove that on http://rusic.com/themes/1/edit